### PR TITLE
Make Jukebox moveable, return optional instead of unique_ptr

### DIFF
--- a/src/app/controller.cpp
+++ b/src/app/controller.cpp
@@ -18,6 +18,17 @@ Controller::Controller(Input::signal&& signal) : m_signal(std::move(signal)) {
 	m_signal += [this](Key key) { onKey(key); };
 }
 
+Controller::Controller(Controller&& rhs) noexcept : m_list(std::move(rhs.m_list)), m_signal(std::move(rhs.m_signal)) { replaceBindings(); }
+
+Controller& Controller::operator=(Controller&& rhs) noexcept {
+	if (&rhs != this) {
+		m_list = std::move(rhs.m_list);
+		m_signal = std::move(rhs.m_signal);
+		replaceBindings();
+	}
+	return *this;
+}
+
 void Controller::onKey(Key key) noexcept {
 	if (key.press() || key.repeat()) {
 		float const magnitude = key.repeat() ? 0.01f : 0.05f;
@@ -50,5 +61,9 @@ void Controller::onKey(Key key) noexcept {
 
 void Controller::add(Action action, float value) noexcept {
 	if (m_list.has_space()) { m_list.push_back({value, action}); }
+}
+
+void Controller::replaceBindings() noexcept {
+	m_signal.replace(m_signal.tag(), [this](Key key) { onKey(key); });
 }
 } // namespace jk

--- a/src/app/controller.hpp
+++ b/src/app/controller.hpp
@@ -17,12 +17,15 @@ class Controller {
 	using Input = ktl::delegate<Key>;
 
 	Controller(Input::signal&& signal);
+	Controller(Controller&&) noexcept;
+	Controller& operator=(Controller&&) noexcept;
 
 	ResponseList update() noexcept { return std::exchange(m_list, ResponseList()); }
 
   private:
 	void onKey(Key key) noexcept;
 	void add(Action action, float value = {}) noexcept;
+	void replaceBindings() noexcept;
 
 	ResponseList m_list;
 	Input::signal m_signal;


### PR DESCRIPTION
- Controller, Jukebox: use ktl updates to replace bound callbacks on move instead of pop/push.
- Ensure moves are noexcept (no new allocations are made).
- Use `ktl::enum_flags` instead of multiple bools.

Notes: the callbacks capture `this`, thus must be re-set on moves. Prior to the most recent `ktl::delegate` updates, this could only be done via popping an existing callback and pushing a new one, which was not an exception safe approach. Now move semantics swap out existing bound callbacks with a fresh `this` capture, enabling them to be `noexcept`. Additionally, this allows `Jukebox` to be moveable and `make()` to return an `optional` instead of a `unique_ptr`. (Note that `capo::Instance` is now on the heap, which was the blocker against moveable jukebox before the fix to #16.)